### PR TITLE
adjust background_dark accent color for dark mode

### DIFF
--- a/lua/gruvbox-baby/colors.lua
+++ b/lua/gruvbox-baby/colors.lua
@@ -60,7 +60,7 @@ function M.config(config)
     ["dark"] = {
       dark = colors.dark0,
       background = colors.background_dark,
-      background_dark = colors.background_dark,
+      background_dark = colors.medium_gray,
     },
     ["medium"] = {
       background = colors.background,


### PR DESCRIPTION
Currently 'color.background' and 'color.background_dark' are set to the same
value, when specifiying `vim.g.gruvbox_baby_background_color = "dark"`.

I've adjusted the 'color.background_dark' accent color to be visible
again.