### PR TITLE
Override higlights in transparent mode

### DIFF
--- a/lua/gruvbox-baby/theme.lua
+++ b/lua/gruvbox-baby/theme.lua
@@ -390,6 +390,14 @@ function M.setup(config)
     })
   end
 
+  if config.transparent_mode then
+    theme.base = vim.tbl_extend("force", theme.base, {
+      Visual = { bg = c.medium_gray },
+      MultiCursor = { bg = c.medium_gray },
+      Cursor = { bg = c.soft_green, c.dark }
+    })
+  end
+
   theme.base = vim.tbl_extend("force", theme.base, config.highlights or {})
   return theme
 end


### PR DESCRIPTION
Added this highlight change as the transparent mode breaks with

https://github.com/luisiacc/gruvbox-baby/commit/1bf3dcbdaf66d7b5a0d93d4f63772b9f28bb644e

As the background is set to NONE, these highlights would set the cursor to None.
I reverted it to what it was with this specific override. Maybe it can be handled differently.