### PR TITLE
Added support for @storageclass.lifetime

### DIFF
--- a/lua/gruvbox-baby/theme.lua
+++ b/lua/gruvbox-baby/theme.lua
@@ -45,6 +45,7 @@ function M.link_new_highlights()
     highlight! link @punctuation.special TSPunctSpecial
     highlight! link @repeat TSRepeat
     highlight! link @storageclass TSStorageClass
+    highlight! link @storageclass.lifetime TSStorageClassLifetime
     highlight! link @string TSString
     highlight! link @string.escape TSStringEscape
     highlight! link @string.regex TSStringRegex
@@ -187,7 +188,8 @@ function M.setup(config)
     TSException = { fg = c.red },
     TSType = { fg = c.clean_green },
     TSTypeBuiltin = { fg = c.blue_gray },
-    TSTypeQualifier = { fg = c.orange},
+    TSTypeQualifier = { fg = c.orange },
+    TSStorageClassLifetime = {fg = c.orange},
     TSStructure = { fg = c.blue_gray },
     TSVariable = { fg = c.light_blue, style = config.variable_style },
     TSVariableBuiltin = { fg = c.blue_gray },


### PR DESCRIPTION
@storageclass.lifetime / TSStorageClassLifetime
Added in highlight groups for Rust lifetime syntax. (The <`a> marks, if unfamiliar)

![image](https://user-images.githubusercontent.com/26173007/202072599-91fb2983-71d8-488e-b371-f58276239f6d.png)
