### PR TITLE
add Dashboard highlight groups

### DIFF
--- a/lua/gruvbox-baby/theme.lua
+++ b/lua/gruvbox-baby/theme.lua
@@ -386,6 +386,12 @@ function M.setup(config)
     IlluminatedWordText = { bg = c.background_light },
     IlluminatedWordRead = { bg = c.background_light },
     IlluminatedWordWrite = { bg = c.background_light },
+
+    -- Dashboard
+    DashboardHeader = { fg = c.red },
+    DashboardShortCut = { fg = c.light_blue },
+    DashboardCenter = { fg = c.bright_yellow },
+    DashboardFooter = { fg = c.blue_gray },
   }
 
   if config.telescope_theme then


### PR DESCRIPTION
I use the Alpha dashboard (https://github.com/goolord/alpha-nvim) for a simple start screen, with this theme there is no highlighting unlike many other themes I've tried. This PR adds the highlight groups necessary to show some color, I'm not 100% on the colors but I figured this would be a decent start point.

Thanks!