### PR TITLE
fix: Correct false linked XCode repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ require('lualine').setup {
 - **bash/zsh** color themes found on [extras](extras/bash)
 - **Windows Terminal** color themes found on [extras](extras/windows_terminal)
 - **fzf** color theme found on [extras](extras/fzf)
-- **XCode Colorscheme** color theme found on [jstheoriginal/gruvbox-theme-for-xcode](https://github.com/jstheoriginal/gruvbox-theme-for-xcode)
+- **XCode Colorscheme** color theme found on [adityadaniel/gruvbox-baby-xcode](https://github.com/adityadaniel/gruvbox-baby-xcode)
 
 #### add to Windows Terminal
 
@@ -256,4 +256,4 @@ export FZF_DEFAULT_OPTS="${FZF_DEFAULT_OPTS} ${FZF_THEME}"
 - Shutout to @ThePrimeagen for the inspiration for the plugin name, Gruvbox baby!
 - I based my structure on https://github.com/folke/tokyonight.nvim (and also copied some of it)
 - The all father 👴 https://github.com/morhetz/gruvbox
-- To @jstheoriginal to make the theme available for 🍎 XCode
+- To @adityadaniel to make the theme available for 🍎 XCode


### PR DESCRIPTION
I'm so sorry!

I mistakenly added the XCode theme for the original gruvbox theme...
This PR updates the reference to the actual gruvbox-baby XCode theme made by @adityadaniel.

@adityadaniel I hope you're okay with adding a reference here?

@jstheoriginal I'm so sorry to having bothered or confused you with that. Unfortunately, we have to remove that reference to your awesome work here. Sorry for any circumstances.