### PR TITLE
fix: change lualine `terminal` mode to `insert` mode

### DIFF
--- a/lua/lualine/themes/gruvbox-baby.lua
+++ b/lua/lualine/themes/gruvbox-baby.lua
@@ -3,7 +3,7 @@
 -- stylua: ignore
 local c = require("gruvbox-baby.colors").config()
 
-return {
+local M = {
   normal = {
     a = { bg = c.light_blue, fg = c.dark, gui = "bold" },
     b = { bg = c.background, fg = c.light_blue },
@@ -35,3 +35,7 @@ return {
     c = { bg = c.dark_gray, fg = c.gray },
   },
 }
+
+M.terminal = M.insert
+
+return M


### PR DESCRIPTION
Lualine `terminal` mode fallback to `normal` mode as default.

This commit change default `terminal` mode to `insert` mode.

Related issue: nvim-lualine/lualine.nvim#989 nvim-lualine/lualine.nvim#912